### PR TITLE
Add Travis CI "build status" button to README #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ If you wish to clone an existing installation, you should perform the following 
 
 This is a community effort, written by [Don Sizemore][donsizemore] and wll include improvements from [Tim Dilauro][tdilauro]. The role is under active development - pull requests, suggestions and other contributions are welcome!
 
+[![Build Status](https://travis-ci.org/IQSS/dataverse-ansible.svg?branch=master)](https://travis-ci.org/IQSS/dataverse-ansible)
+
 [ansible]: http://ansible.com
 [dataverse]: https://dataverse.org
 [iqss]: http://www.iq.harvard.edu


### PR DESCRIPTION
It's nice to see the build status. I stuck it on the bottom like we do for Dataverse but if it's better put at the top, that's fine too.