### PR TITLE
support --extra-vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
   # Check playbook syntax
   - sudo docker exec $(cat /tmp/cid) ansible-playbook site.yml --syntax-check
   # Run the playbook
-  - sudo docker exec $(cat /tmp/cid) ansible-playbook site.yml
+  - sudo docker exec $(cat /tmp/cid) ansible-playbook site.yml --extra-vars "branch=develop repo=https://github.com/IQSS/dataverse.git"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,8 +23,8 @@ dataverse:
     provider: EZID
   filesdir: /usr/local/dvn/data
   git:
-    branch:
-    repo: https://github.com/IQSS/dataverse.git
+    branch: '{{ branch }}'
+    repo: '{{ repo }}'
   glassfish:
     user: glassfish
     group: glassfish


### PR DESCRIPTION
To use `--extra-var` I think I need this change. That's my understanding of https://docs.ansible.com/ansible/2.4/playbooks_variables.html#passing-variables-on-the-command-line anyway and it seems to work when I use the following in the script we're working on in https://github.com/IQSS/dataverse/pull/5063

`ansible-playbook -i dataverse/inventory dataverse/dataverse.pb --connection=local --extra-vars "branch=$BRANCH_NAME repo=https://github.com/IQSS/dataverse.git"`