### PR TITLE
bump counter processor version #33

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ dataverse:
     output_format: json
     platform: dash
     robots_url: "https://raw.githubusercontent.com/CDLUC3/Make-Data-Count/master/user-agents/lists/robot.txt"
-    version: "0.0.1"
+    version: "0.1"
     upload_to_hub: False
     user: counter
     year_month: "2018-05"

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -21,7 +21,7 @@ dataverse:
     output_format: json
     platform: dash
     robots_url: "https://raw.githubusercontent.com/CDLUC3/Make-Data-Count/master/user-agents/lists/robot.txt"
-    version: "0.0.1"
+    version: "0.1"
     upload_to_hub: False
     user: counter
     year_month: "2018-05"


### PR DESCRIPTION
updating to latest release: https://github.com/CDLUC3/counter-processor/releases/tag/v0.1