### PR TITLE
Add missing sudo package

### DIFF
--- a/tasks/dataverse-prereqs.yml
+++ b/tasks/dataverse-prereqs.yml
@@ -22,7 +22,7 @@
 
 - name: install java-nnn-openjdk and other packages for RedHat/CentOS.
   yum:
-   name: ['bash-completion', 'elinks', 'git', 'java-{{ dataverse.java.version }}-openjdk-devel', 'jq', 'net-tools', 'perl', 'python-psycopg2', 'unzip']
+   name: ['bash-completion', 'elinks', 'git', 'java-{{ dataverse.java.version }}-openjdk-devel', 'jq', 'net-tools', 'perl', 'python-psycopg2', 'sudo', 'unzip']
    state: latest
   when: ansible_os_family == "RedHat" and
         ansible_distribution_major_version == "7"


### PR DESCRIPTION
CentOS 7 LXD containers do not have the 'sudo' package preinstalled. Extended package list to include it.

fixes #45