### PR TITLE
s/notPr0d/admin1/ for dataverseAdmin password #44

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # dataverse/defaults/main.yml
 
 dataverse:
-  adminpass: notPr0d
+  adminpass: admin1
   allow_signups: true
   api:
     blocked_endpoints: "admin,test"

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -2,7 +2,7 @@
 # dataverse/tests/group_vars/vagrant.yml
 
 dataverse:
-  adminpass: notPr0d
+  adminpass: admin1
   allow_signups: true
   api:
     blocked_endpoints: "admin,test"


### PR DESCRIPTION
Fixes #44 

admin1 is what @mheppler and I use on "phoenix" and other servers.

See also https://github.com/IQSS/dataverse/issues/4178

Please note that I left the Glassfish password as notPr0d. I don't care what that password is. 😄 