### PR TITLE
bump version to 4.12

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,7 +72,7 @@ dataverse:
     version: 7.3.1
   srcdir: /tmp/dataverse
   thumbnails: true
-  version: "4.11"
+  version: "4.12"
 rserve:
   host: rserve.yourinstitution.edu
   user: rserve


### PR DESCRIPTION
Update default version to reflect the latest release. A one-off run in a LXD container resulted in v4.12 installed and ready for testing.

CC: @auadamw