### PR TITLE
#155 initial redeploy script for EC2 instances and possibly others

### DIFF
--- a/tasks/dataverse-build.yml
+++ b/tasks/dataverse-build.yml
@@ -79,3 +79,11 @@
     remote_src: yes
   with_fileglob:
     - "{{ dataverse.srcdir }}/target/dataverse*.war"
+
+- name: place redeploy script
+  template:
+    src: redeploy.sh.j2
+    dest: '{{ dataverse.srcdir }}/redeploy.sh'
+    owner: root
+    group: root
+    mode: 0755

--- a/templates/redeploy.sh.j2
+++ b/templates/redeploy.sh.j2
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+ASADMIN={{ dataverse.glassfish.root }}/{{ dataverse.glassfish.dir }}/bin/asadmin
+
+# update, build
+cd {{ dataverse.srcdir }}
+/usr/bin/sudo /usr/bin/git pull
+/usr/bin/sudo /usr/bin/mvn package
+
+# undeploy
+CURRENT=`/usr/bin/sudo -u {{ dataverse.glassfish.user }} $ASADMIN list-applications -t | awk '{print $1}'`
+/usr/bin/sudo -u {{ dataverse.glassfish.user }} $ASADMIN undeploy $CURRENT
+/usr/bin/sleep 3
+
+# deploy
+/usr/bin/sudo /usr/bin/chmod 644 target/dataverse-*.war
+/usr/bin/sudo -u {{ dataverse.glassfish.user }} $ASADMIN deploy target/dataverse-*.war
+/usr/bin/sleep 3
+
+# restart
+/usr/bin/sudo -u {{ dataverse.glassfish.user }} $ASADMIN stop-domain
+/usr/bin/sleep 3
+/usr/bin/sudo -u {{ dataverse.glassfish.user }} $ASADMIN start-domain


### PR DESCRIPTION
@mheppler it's a start. could be called remotely by appending (the default) /tmp/dataverse/redeploy.sh to the SSH command spat out by the ec2-create script, or locally as needed. a good use case for dvcli!