### PR TITLE
no upstart script install over debian 9

### DIFF
--- a/tasks/dataverse-glassfish.yml
+++ b/tasks/dataverse-glassfish.yml
@@ -157,7 +157,10 @@
 - name: install glassfish upstart script for Debian/Ubuntu
   template: src=glassfish.conf.j2 dest=/etc/init
         owner=root group=root mode=0644
-  when: ansible_os_family == "Debian"
+  when:
+   - ansible_os_family == "Debian"
+   - ansible_distribution_major_version < 9
+  notify: enable and restart glassfish
 
 - name: start glassfish with asadmin so subsequent Ansible-initiated restarts succeed on RedHat/CentOS
   become: yes


### PR DESCRIPTION
debian 9 and up use systemd instead of upstart, so installing upstart scripts is unnecessary and causes glassfish to restart at each run