### PR TITLE
centos 8.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "bento/centos-7.8"
+  config.vm.box = "bento/centos-8.2"
 
   config.vm.synced_folder ".", "/vagrant"
   config.vm.synced_folder ".", "/etc/ansible/roles/dataverse"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -163,7 +163,7 @@ db:
     pass: dvnsecret
     jdbcurl: 
     log_lock_waits: true
-    version: 9.6
+    version: 10
     port: 5432
   use_rds: false
 

--- a/ec2/ec2-create-instance.sh
+++ b/ec2/ec2-create-instance.sh
@@ -6,7 +6,12 @@
 REPO_URL_DEFAULT='https://github.com/IQSS/dataverse.git'
 BRANCH_DEFAULT='develop'
 PEM_DEFAULT=${HOME}
-AWS_AMI_DEFAULT='ami-9887c6e7'
+
+# centos image list at https://wiki.centos.org/Cloud/AWS
+# centos 7
+#AWS_AMI_DEFAULT='ami-9887c6e7'
+# centos 8.2, us-east-1
+AWS_AMI_DEFAULT='ami-01ca03df4a6012157'
 
 usage() {
   echo "Usage: $0 -b <branch> -r <repo> -p <pem_dir> -g <group_vars> -a <dataverse-ansible branch> -i aws_image -s aws_size -t aws_tag -l local_log_path -d" 1>&2
@@ -156,9 +161,9 @@ echo "Instance ID: "$INSTANCE_ID
 DESTROY_CMD="aws ec2 terminate-instances --instance-ids $INSTANCE_ID"
 echo "When you are done, please terminate your instance with:"
 echo "$DESTROY_CMD"
-echo "giving instance 60 seconds to wake up..."
+echo "giving instance 90 seconds to wake up..."
 
-sleep 60
+sleep 90
 echo "End creating EC2 instance"
 
 PUBLIC_DNS=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query "Reservations[*].Instances[*].[PublicDnsName]" --output text)

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -25,8 +25,7 @@
   yum: 
     name: ['httpd', 'mod_ssl']
     state: latest
-  when: ansible_os_family == "RedHat" and
-        ansible_distribution_major_version == "7"
+  when: ansible_os_family == "RedHat"
 
 - name: install Apache for Debian/Ubuntu
   package:
@@ -80,7 +79,6 @@
 - include: certbot.yml
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version == "7"
     - apache.ssl.enabled
     - letsencrypt.enabled
 

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -5,6 +5,12 @@
   debug:
     msg: '##### APACHE/HTTPD #####'
 
+- name: allow apache to make outbound connections
+  shell: '/usr/sbin/setsebool -P httpd_can_network_connect 1'
+  when:
+  - ansible_os_family == "RedHat"
+  - ansible_distribution_major_version == "8"
+
 - name: httpd variables
   set_fact:
     apache_config_base_dir: "{{ (ansible_os_family == 'RedHat') | ternary ('/etc/httpd', '/etc/apache2') }}"

--- a/tasks/dataverse-prereqs.yml
+++ b/tasks/dataverse-prereqs.yml
@@ -84,3 +84,11 @@
   when:
     - ansible_os_family == "Debian"
   tags: prereqs
+
+- name: Dataverse installer calls /usr/bin/python explicitly
+  alternatives:
+    name: python
+    link: /usr/bin/python
+    path: '/usr/bin/python3'
+  when: ansible_os_family == "RedHat" and
+        ansible_distribution_major_version == "8"

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -159,7 +159,7 @@ db:
     pass: dvnsecret
     jdbcurl:
     log_lock_waits: true
-    version: 9.6
+    version: 10
     port: 5432
   use_rds: false
 


### PR DESCRIPTION
now that we have official CentOS 8 images available in EC2, let's default to CentOS 8 in EC2 and Vagrant. 

closes #206 